### PR TITLE
Preventing query being overridden on the settings/notifications page

### DIFF
--- a/humanities-commons.php
+++ b/humanities-commons.php
@@ -419,7 +419,7 @@ class Humanities_Commons {
 
 	public function hcommons_set_groups_query_args( $args ) {
 		// profile loops per-type, leave as-is
-		if ( bp_is_user_profile() ) {
+		if ( bp_is_user_profile() || ( bp_is_settings_component() && bp_is_current_action( 'notifications' ) ) ) {
 			return $args;
 		}
 


### PR DESCRIPTION
Preventing group_type from being overridden by specific societies on the email settings page. 