### PR TITLE
Flipping argument from false to true in the multiple forum group filter

### DIFF
--- a/humanities-commons.php
+++ b/humanities-commons.php
@@ -531,7 +531,7 @@ class Humanities_Commons {
 				'group_type__in'     => $r['group_type__in'],
 				'group_type__not_in' => $r['group_type__not_in'],
 				'meta_query'         => $r['meta_query'],
-				'show_hidden'        => FALSE,
+				'show_hidden'        => TRUE,
 				'per_page'           => $r['per_page'],
 				'page'               => $r['page'],
 				'populate_extras'    => $r['populate_extras'],


### PR DESCRIPTION
Plugin contains a function that checks if a Multi Forum Post function is being called and sets the show_hidden to false, changing this back to true. 