### PR TITLE
Fixing new blog posts in activity streams

### DIFF
--- a/humanities-commons.php
+++ b/humanities-commons.php
@@ -162,8 +162,6 @@ class Humanities_Commons {
 		add_filter( 'wpmu_active_signup', array( $this, 'hcommons_check_sites_new_member_status' ) );
 		add_shortcode( 'hcommons_society_page', array( $this, 'hcommons_get_society_page_by_slug' ) );
 		add_shortcode( 'hcommons_env_variable', array( $this, 'hcommons_get_env_variable' ) );
-		add_filter( 'bp_blogs_format_activity_action_new_blog_post', array( $this, 'hcommons_blogs_format_activity_new_blog_post' ),  10, 2 );
-		add_filter( 'bp_blogs_format_activity_action_new_blog_comment', array( $this, 'hcommons_blogs_format_activity_new_blog_comment' ), 10, 2 );
 
 	}
 


### PR DESCRIPTION
Activity object no longer contains "action", these functions will produce an error which will prevent the blog post/comment from appearing in activity streams. 